### PR TITLE
Adapt wording if there is only 1 supervisor

### DIFF
--- a/Front/imprint.tex
+++ b/Front/imprint.tex
@@ -40,7 +40,7 @@
 
 \begin{minipage}[t]{0.50\textwidth}
 \begin{flushleft} 
-\emph{Supervisor 1:}\\
+\emph{Supervisor\ifdefempty{\supnameB}{}{ 1}:}\\
 \supinfoA
 \end{flushleft}
 \end{minipage}

--- a/Front/titlepage.tex
+++ b/Front/titlepage.tex
@@ -46,9 +46,9 @@
 \begin{minipage}[t]{0.4\textwidth}
 \begin{flushright} 
     \large
-    \emph{Supervisors:} \\
-    \supnameA \\
-    \supnameB
+    \emph{Supervisor\ifdefempty{\supnameB}{}{s}:}\\
+    \supnameA
+    \ifdefempty{\supnameB}{}{\\ \supnameB}
 \end{flushright}
 \end{minipage}
 \vspace{2cm}


### PR DESCRIPTION
Hi there,

Thanks for this template :)

I only have one supervisor for my project and noticed that it would still say _Supervisors_ and _Supervisor 1_ in the report. I adapted it to _Supervisor_ in case there is only one supervisor.

Best Regards,
Jason